### PR TITLE
update to 2021.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ condacolab.check()
 
 The default `condacolab.install()` provides Mambaforge, but there are other `conda` distributions to choose from:
 
-- `install_anaconda()`: This will install the Anaconda 2021.11 distribution, the last version that was built for Python 3.7. This contains [plenty of data science packages](https://docs.anaconda.com/anaconda/packages/old-pkg-lists/2021.11/py3.7_linux-64/), but they might be outdated by now.
+- `install_anaconda()`: This will install the Anaconda 2022.05 distribution, the most recent version built for Python 3.7 at the time of update. This contains [plenty of data science packages (link to current version docs))](https://docs.anaconda.com/anaconda/packages/py3.7_linux-64/).
 - `install_miniconda()`: This will install the Miniconda 4.12.0 distribution, using a version built for Python 3.7. Unlike Anaconda, this distribution only contains `python` and `conda`.
 - `install_miniforge()`: Like Miniconda, but built off `conda-forge` packages. The Miniforge distribution is officially provided by [conda-forge](https://github.com/conda-forge/miniforge) but I [forked and patched it](https://github.com/jaimergp/miniforge) so it's built for Python 3.7.
 - `install_mambaforge()`: Like Miniforge, but with `mamba` included. The Mambaforge distribution is officially provided by [conda-forge](https://github.com/conda-forge/miniforge) but I [forked and patched it](https://github.com/jaimergp/miniforge) so it's built for Python 3.7.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ condacolab.check()
 
 The default `condacolab.install()` provides Mambaforge, but there are other `conda` distributions to choose from:
 
-- `install_anaconda()`: This will install the Anaconda 2020.02 distribution, the last version that was built for Python 3.7. This contains [plenty of data science packages](https://docs.anaconda.com/anaconda/packages/old-pkg-lists/2020.02/py3.7_linux-64/), but they might be outdated by now.
+- `install_anaconda()`: This will install the Anaconda 2021.11 distribution, the last version that was built for Python 3.7. This contains [plenty of data science packages](https://docs.anaconda.com/anaconda/packages/old-pkg-lists/2021.11/py3.7_linux-64/), but they might be outdated by now.
 - `install_miniconda()`: This will install the Miniconda 4.9.2 distribution, using a version built for Python 3.7. Unlike Anaconda, this distribution only contains `python` and `conda`.
 - `install_miniforge()`: Like Miniconda, but built off `conda-forge` packages. The Miniforge distribution is officially provided by [conda-forge](https://github.com/conda-forge/miniforge) but I [forked and patched it](https://github.com/jaimergp/miniforge) so it's built for Python 3.7.
 - `install_mambaforge()`: Like Miniforge, but with `mamba` included. The Mambaforge distribution is officially provided by [conda-forge](https://github.com/conda-forge/miniforge) but I [forked and patched it](https://github.com/jaimergp/miniforge) so it's built for Python 3.7.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ condacolab.check()
 
 The default `condacolab.install()` provides Mambaforge, but there are other `conda` distributions to choose from:
 
-- `install_anaconda()`: This will install the Anaconda 2022.05 distribution, the most recent version built for Python 3.7 at the time of update. This contains [plenty of data science packages (link to current version docs))](https://docs.anaconda.com/anaconda/packages/py3.7_linux-64/).
+- `install_anaconda()`: This will install the Anaconda 2022.05 distribution, the most recent version built for Python 3.7 at the time of update. This contains [plenty of data science packages (link to current version docs)](https://docs.anaconda.com/anaconda/packages/py3.7_linux-64/).
 - `install_miniconda()`: This will install the Miniconda 4.12.0 distribution, using a version built for Python 3.7. Unlike Anaconda, this distribution only contains `python` and `conda`.
 - `install_miniforge()`: Like Miniconda, but built off `conda-forge` packages. The Miniforge distribution is officially provided by [conda-forge](https://github.com/conda-forge/miniforge) but I [forked and patched it](https://github.com/jaimergp/miniforge) so it's built for Python 3.7.
 - `install_mambaforge()`: Like Miniforge, but with `mamba` included. The Mambaforge distribution is officially provided by [conda-forge](https://github.com/conda-forge/miniforge) but I [forked and patched it](https://github.com/jaimergp/miniforge) so it's built for Python 3.7.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ condacolab.check()
 The default `condacolab.install()` provides Mambaforge, but there are other `conda` distributions to choose from:
 
 - `install_anaconda()`: This will install the Anaconda 2021.11 distribution, the last version that was built for Python 3.7. This contains [plenty of data science packages](https://docs.anaconda.com/anaconda/packages/old-pkg-lists/2021.11/py3.7_linux-64/), but they might be outdated by now.
-- `install_miniconda()`: This will install the Miniconda 4.9.2 distribution, using a version built for Python 3.7. Unlike Anaconda, this distribution only contains `python` and `conda`.
+- `install_miniconda()`: This will install the Miniconda 4.12.0 distribution, using a version built for Python 3.7. Unlike Anaconda, this distribution only contains `python` and `conda`.
 - `install_miniforge()`: Like Miniconda, but built off `conda-forge` packages. The Miniforge distribution is officially provided by [conda-forge](https://github.com/conda-forge/miniforge) but I [forked and patched it](https://github.com/jaimergp/miniforge) so it's built for Python 3.7.
 - `install_mambaforge()`: Like Miniforge, but with `mamba` included. The Mambaforge distribution is officially provided by [conda-forge](https://github.com/conda-forge/miniforge) but I [forked and patched it](https://github.com/jaimergp/miniforge) so it's built for Python 3.7.
 

--- a/condacolab.py
+++ b/condacolab.py
@@ -223,7 +223,7 @@ def install_miniconda(
     prefix: os.PathLike = PREFIX, env: Dict[AnyStr, AnyStr] = None, run_checks: bool = True
 ):
     """
-    Install Miniconda 4.9.2 for Python 3.7.
+    Install Miniconda 4.12.0 for Python 3.7.
 
     Parameters
     ----------

--- a/condacolab.py
+++ b/condacolab.py
@@ -244,7 +244,7 @@ def install_miniconda(
         Change to False to ignore checks and always attempt
         to run the installation.
     """
-    installer_url = r"https://repo.anaconda.com/miniconda/Miniconda3-py37_4.9.2-Linux-x86_64.sh"
+    installer_url = r"https://repo.anaconda.com/miniconda/Miniconda3-py37_4.12.0-Linux-x86_64.sh"
     install_from_url(installer_url, prefix=prefix, env=env, run_checks=run_checks)
 
 

--- a/condacolab.py
+++ b/condacolab.py
@@ -274,7 +274,7 @@ def install_anaconda(
         Change to False to ignore checks and always attempt
         to run the installation.
     """
-    installer_url = r"https://repo.anaconda.com/archive/Anaconda3-2020.02-Linux-x86_64.sh"
+    installer_url = r"https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-x86_64.sh"
     install_from_url(installer_url, prefix=prefix, env=env, run_checks=run_checks)
 
 

--- a/condacolab.py
+++ b/condacolab.py
@@ -252,8 +252,8 @@ def install_anaconda(
     prefix: os.PathLike = PREFIX, env: Dict[AnyStr, AnyStr] = None, run_checks: bool = True
 ):
     """
-    Install Anaconda 2020.02, the last official version built
-    for Python 3.7.
+    Install Anaconda 2022.05, the latest version built
+    for Python 3.7 at the time of update.
 
     Parameters
     ----------
@@ -274,7 +274,7 @@ def install_anaconda(
         Change to False to ignore checks and always attempt
         to run the installation.
     """
-    installer_url = r"https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-x86_64.sh"
+    installer_url = r"https://repo.anaconda.com/archive/Anaconda3-2022.05-Linux-x86_64.sh"
     install_from_url(installer_url, prefix=prefix, env=env, run_checks=run_checks)
 
 


### PR DESCRIPTION
## Description
Update the Anaconda distribution to 2021.11

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Changed the download URL
  - [x] Change the version number in the README
  - [x] Change the documentation link in README to new version link

## Questions
- [x] There is actually a more recent 2022.05 distribution available, but the documentation link is not live. I have chosen to use the older distribution rather than removing the documentation URL (or keeping an inconsistent documentation URL).

## Status
- [x] Ready to go