### PR TITLE
Add script to activate base environment

### DIFF
--- a/condacolab.py
+++ b/condacolab.py
@@ -195,6 +195,7 @@ def install_from_url(
                 source {prefix}/etc/profile.d/conda.sh
                 conda activate
                 unset PYTHONPATH
+                mv /usr/bin/lsb_release /usr/bin/lsb_release_back
                 exec {bin_path}/python $@
                 """
             ).lstrip()

--- a/condacolab.py
+++ b/condacolab.py
@@ -38,8 +38,10 @@ except ImportError:
 
 
 __version__ = "0.1.4"
-__author__ = "Jaime Rodríguez-Guerra <jaimergp@users.noreply.github.com>"
-__author__= "Surbhi Sharma <ssurbhi560@users.noreply.github.com>"
+__author__ = (
+    "Jaime Rodríguez-Guerra <jaimergp@users.noreply.github.com>, "
+    "Surbhi Sharma <ssurbhi560@users.noreply.github.com>"
+)
 
 
 PREFIX = "/opt/conda"

--- a/condacolab.py
+++ b/condacolab.py
@@ -39,9 +39,10 @@ except ImportError:
 
 __version__ = "0.1.4"
 __author__ = "Jaime Rodríguez-Guerra <jaimergp@users.noreply.github.com>"
+__author__= "Surbhi Sharma <ssurbhi560@users.noreply.github.com>"
 
 
-PREFIX = "/opt/miniconda"
+PREFIX = "/opt/conda"
 
 if HAS_IPYWIDGETS:
     restart_kernel_button = widgets.Button(description="Restart kernel now...")

--- a/condacolab.py
+++ b/condacolab.py
@@ -77,7 +77,7 @@ def run_subprocess(bash_command, logs_filename):
 
     with open(logs_filename, "w") as f:
         f.write(task.stdout)
-    assert ( task.returncode == 0), f"💥💔💥 The installation failed! Logs are available at `/content/{logs_filename}`."
+    assert (task.returncode == 0), f"💥💔💥 The installation failed! Logs are available at `/content/{logs_filename}`."
 
 
 def install_from_url(
@@ -367,12 +367,14 @@ def check(prefix: os.PathLike = PREFIX, verbose: bool = True):
     pymaj, pymin = sys.version_info[:2]
     sitepackages = f"{prefix}/lib/python{pymaj}.{pymin}/site-packages"
     assert sitepackages in sys.path, f"💥💔💥 PYTHONPATH was not patched! Value: {sys.path}"
+    assert "/usr/local/" not in sys.path, "💥💔💥 There is some problem with installation!"
     assert (
         f"{prefix}/bin" in os.environ["PATH"]
     ), f"💥💔💥 PATH was not patched! Value: {os.environ['PATH']}"
     assert (
-        f"{prefix}/lib" in os.environ["LD_LIBRARY_PATH"]
-    ), f"💥💔💥 LD_LIBRARY_PATH was not patched! Value: {os.environ['LD_LIBRARY_PATH']}"
+    prefix == os.environ["CONDA_PREFIX"],
+    ), f"💥💔💥 CONDA_PREFIX Value: {os.environ['CONDA_PREFIX']} does not match conda installation location {prefix}!"
+
     if verbose:
         print("✨🍰✨ Everything looks OK!")
 

--- a/condacolab.py
+++ b/condacolab.py
@@ -49,25 +49,25 @@ if HAS_IPYWIDGETS:
 else:
     restart_kernel_button = restart_button_output = None
 
-def on_button_clicked(b):
+def _on_button_clicked(b):
   with restart_button_output:
     get_ipython().kernel.do_shutdown(True)
     print("Kernel restarted!")
     restart_kernel_button.close()
 
-def run_subprocess(command, logs_filename):
+def _run_subprocess(command, logs_filename):
     """
     Run subprocess then write the logs for that process and raise errors if it fails.
 
-        Parameters
-        ----------
-        command
-            Command to run while installing the packages.
+    Parameters
+    ----------
+    command
+        Command to run while installing the packages.
 
-        logs_filename
-            Name of the file to be used for writing the logs after running the task.
-
+    logs_filename
+        Name of the file to be used for writing the logs after running the task.
     """
+
     task = run(
             command,
             check=False,
@@ -76,7 +76,7 @@ def run_subprocess(command, logs_filename):
             text=True,
         )
 
-    with open(logs_filename, "w") as f:
+    with open(f"/content/{logs_filename}", "w") as f:
         f.write(task.stdout)
     assert (task.returncode == 0), f"💥💔💥 The installation failed! Logs are available at `/content/{logs_filename}`."
 
@@ -130,7 +130,7 @@ def install_from_url(
 
     print("📦 Installing...")
 
-    condacolab_task = run_subprocess(
+    condacolab_task = _run_subprocess(
         ["bash", installer_fn, "-bfp", str(prefix)],
         "condacolab_install.log",
         )
@@ -154,12 +154,12 @@ def install_from_url(
             required_packages.remove(pkg)
 
     if required_packages:
-        run_subprocess( 
+        _run_subprocess(
             [f"{prefix}/bin/{conda_exe}", "install", "-yq", *required_packages],
             "conda_task.log",
         )
 
-    pip_task = run_subprocess(
+    pip_task = _run_subprocess(
         [f"{prefix}/bin/python", "-m", "pip", "-q", "install", "-U", "https://github.com/googlecolab/colabtools/archive/refs/heads/main.zip", "condacolab"],
         "pip_task.log"
         )
@@ -221,7 +221,7 @@ def install_from_url(
 
     elif HAS_IPYWIDGETS:
         print("🔁 Please restart kernel...")
-        restart_kernel_button.on_click(on_button_clicked)
+        restart_kernel_button.on_click(_on_button_clicked)
         display(restart_kernel_button, restart_button_output)
 
     else:
@@ -384,7 +384,7 @@ def check(prefix: os.PathLike = PREFIX, verbose: bool = True):
         f"{prefix}/bin" in os.environ["PATH"]
     ), f"💥💔💥 PATH was not patched! Value: {os.environ['PATH']}"
     assert (
-    prefix == os.environ.get("CONDA_PREFIX"),
+        prefix == os.environ.get("CONDA_PREFIX")
     ), f"💥💔💥 CONDA_PREFIX value: {os.environ.get('CONDA_PREFIX', '<not set>')} does not match conda installation location {prefix}!"
 
     if verbose:

--- a/condacolab.py
+++ b/condacolab.py
@@ -16,6 +16,7 @@ import shutil
 from datetime import datetime, timedelta
 from pathlib import Path
 from subprocess import run, PIPE, STDOUT
+from textwrap import dedent
 from typing import Dict, AnyStr
 from urllib.request import urlopen
 from distutils.spawn import find_executable
@@ -52,6 +53,32 @@ def on_button_clicked(b):
     get_ipython().kernel.do_shutdown(True)
     print("Kernel restarted!")
     restart_kernel_button.close()
+
+def run_subprocess(bash_command, logs_filename):
+    """
+    Run subprocess then write the logs for that process and raise errors if it fails.
+
+        Parameters
+        ----------
+        bash_command
+            Bash command to run while installing the packages.
+
+        logs_filename
+            Name of the file to be used for writing the logs after running the task.
+
+    """
+    task = run(
+            bash_command,
+            check=False,
+            stdout=PIPE,
+            stderr=STDOUT,
+            text=True,
+        )
+
+    with open(logs_filename, "w") as f:
+        f.write(task.stdout)
+    assert ( task.returncode == 0), f"💥💔💥 The installation failed! Logs are available at `/content/{logs_filename}`."
+
 
 def install_from_url(
     installer_url: AnyStr,
@@ -101,46 +128,31 @@ def install_from_url(
         shutil.copyfileobj(response, out)
 
     print("📦 Installing...")
-    task = run(
-        ["bash", installer_fn, "-bfp", str(prefix)],
-        check=False,
-        stdout=PIPE,
-        stderr=STDOUT,
-        text=True,
-    )
 
-    # installing google.colab packages, matplortlib-base and psutil.
+    condacolab_task = run_subprocess(
+        ["bash", installer_fn, "-bfp", str(prefix)],
+        "condacolab_install.log",
+        )
+
+    """
+    Installing the following packages because Colab server expects these packages to be installed in order to launch a Python kernel :
+        - matplotlib-base
+        - psutil
+        - google-colab
+        - colabtools
+    """
 
     conda_exe = "mamba" if os.path.isfile(f"{prefix}/bin/mamba") else "conda"
 
-    psutil_task = run(
+    conda_task = run_subprocess(
         [f"{prefix}/bin/{conda_exe}", "install", "-yq", "matplotlib-base", "psutil", "google-colab"],
-        check=False,
-        stdout=PIPE,
-        stderr=STDOUT,
-        text=True,
-    )
+        "conda_task.log"
+        )
 
-    colab_task = run(
-        [f"{prefix}/bin/python", "-m", "pip", "-q", "install", "https://github.com/googlecolab/colabtools/archive/refs/heads/main.zip", "condacolab"],
-        check=False,
-        stdout=PIPE,
-        stderr=STDOUT,
-        text=True,
-    )
-
-    os.unlink(installer_fn)
-    with open("condacolab_install.log", "w") as f:
-        f.write(task.stdout)
-    with open("colab_task.log", "w") as f:
-        f.write(colab_task.stdout)
-    with open("psutil_task.log", "w") as f:
-        f.write(psutil_task.stdout)
-    assert (
-        task.returncode == 0 and
-        colab_task.returncode  == 0 and
-        psutil_task.returncode == 0
-    ), "💥💔💥 The installation failed! Logs are available at `/content/condacolab_install.log`."
+    pip_task = run_subprocess(
+        [f"{prefix}/bin/python", "-m", "pip", "-q", "install", "-U", "https://github.com/googlecolab/colabtools/archive/refs/heads/main.zip", "condacolab"],
+        "pip_task.log"
+        )
 
     print("📌 Adjusting configuration...")
     cuda_version = ".".join(os.environ.get("CUDA_VERSION", "*.*.*").split(".")[:2])
@@ -174,13 +186,19 @@ def install_from_url(
     env = env or {}
     bin_path = f"{prefix}/bin"
 
-    os.rename(sys.executable, f"{sys.executable}.real")
+    os.rename(sys.executable, f"{sys.executable}.renamed_by_condacolab.bak")
     with open(sys.executable, "w") as f:
-        f.write("#!/bin/bash\n")
-        f.write(f"source {prefix}/etc/profile.d/conda.sh\n")
-        f.write("conda activate\n")
-        f.write(f"unset PYTHONPATH\n")
-        f.write(f"exec {bin_path}/python $@\n")
+        f.write(
+            dedent(
+                f"""
+                #!/bin/bash
+                source {prefix}/etc/profile.d/conda.sh
+                conda activate
+                unset PYTHONPATH
+                exec {bin_path}/python $@
+                """
+            ).lstrip()
+        )
     run(["chmod", "+x", sys.executable])
 
     taken = timedelta(seconds=round((datetime.now() - t0).total_seconds(), 0))

--- a/condacolab.py
+++ b/condacolab.py
@@ -367,13 +367,15 @@ def check(prefix: os.PathLike = PREFIX, verbose: bool = True):
     pymaj, pymin = sys.version_info[:2]
     sitepackages = f"{prefix}/lib/python{pymaj}.{pymin}/site-packages"
     assert sitepackages in sys.path, f"💥💔💥 PYTHONPATH was not patched! Value: {sys.path}"
-    assert "/usr/local/" not in sys.path, "💥💔💥 There is some problem with installation!"
+    assert all(
+        not path.startswith("/usr/local/") for path in sys.path
+    ), f"💥💔💥 PYTHONPATH include system locations: {[path for path in sys.path if path.startswith('/usr/local')]}!"
     assert (
         f"{prefix}/bin" in os.environ["PATH"]
     ), f"💥💔💥 PATH was not patched! Value: {os.environ['PATH']}"
     assert (
-    prefix == os.environ["CONDA_PREFIX"],
-    ), f"💥💔💥 CONDA_PREFIX Value: {os.environ['CONDA_PREFIX']} does not match conda installation location {prefix}!"
+    prefix == os.environ.get("CONDA_PREFIX"),
+    ), f"💥💔💥 CONDA_PREFIX value: {os.environ.get('CONDA_PREFIX', '<not set>')} does not match conda installation location {prefix}!"
 
     if verbose:
         print("✨🍰✨ Everything looks OK!")


### PR DESCRIPTION
## Description
Currently, we install the Miniconda distribution on top of the existing one at `/usr/local`, and add a few configuration files. We stay with Python 3.7, and the newly installed packages are available. Finally, we wrap the Python executable to redirect and inject some environment variables needed to load the new libraries. 

With this new approach that we are implementing in this PR, we will now install the Miniconda distribution (or any other distribution) at `/opt/miniconda` along with other required packages, like `google-colab`, `condatools`, `psutil`, `matplotlib-base`. After this, we overwrite the Python executable to activate the newly created conda base environment and use conda's python instead of colab's. 

You can check this example notebook demonstrating the new feature [here](https://colab.research.google.com/drive/1WQuDyaPhNAWj4xVbZ-yTo4LKwfMuEJgt?usp=sharing).

## Todos
- [x] Fix `check` function.
- [ ] Update the README.md

## Question
- Should we provide this new approach as an option while still keeping the older one?

## Status
- [x] Ready to go