### PR TITLE
Update location of logs files generated during condacolab installation.

### DIFF
--- a/condacolab.py
+++ b/condacolab.py
@@ -138,6 +138,11 @@ def install_from_url(
     with urlopen(installer_url) as response, open(installer_fn, "wb") as out:
         shutil.copyfileobj(response, out)
 
+    condacolab_task = _run_subprocess(
+        ["bash", installer_fn, "-bfp", str(prefix)],
+        "condacolab_install.log",
+        )
+
     print("📌 Adjusting configuration...")
     cuda_version = ".".join(os.environ.get("CUDA_VERSION", "*.*.*").split(".")[:2])
     prefix = Path(prefix)
@@ -151,11 +156,6 @@ def install_from_url(
         f.write("always_yes: true\n")
 
     print("📦 Installing...")
-
-    condacolab_task = _run_subprocess(
-        ["bash", installer_fn, "-bfp", str(prefix)],
-        "condacolab_install.log",
-        )
 
 # Installing the following packages because Colab server expects these packages to be installed in order to launch a Python kernel:
 #     - matplotlib-base

--- a/condacolab.py
+++ b/condacolab.py
@@ -139,6 +139,35 @@ def install_from_url(
     with urlopen(installer_url) as response, open(installer_fn, "wb") as out:
         shutil.copyfileobj(response, out)
 
+    print("📌 Adjusting configuration...")
+    cuda_version = ".".join(os.environ.get("CUDA_VERSION", "*.*.*").split(".")[:2])
+    prefix = Path(prefix)
+    condameta = prefix / "conda-meta"
+    condameta.mkdir(parents=True, exist_ok=True)
+    pymaj, pymin = sys.version_info[:2]
+
+    with open(condameta / "pinned", "a") as f:
+        f.write(f"python {pymaj}.{pymin}.*\n")
+        f.write(f"python_abi {pymaj}.{pymin}.* *cp{pymaj}{pymin}*\n")
+        f.write(f"cudatoolkit {cuda_version}.*\n")
+
+    with open(prefix / ".condarc", "a") as f:
+        f.write("always_yes: true\n")
+
+    with open("/etc/ipython/ipython_config.py", "a") as f:
+        f.write(
+            f"""\nc.InteractiveShellApp.exec_lines = [
+                    "import sys",
+                    "sp = f'{prefix}/lib/python{pymaj}.{pymin}/site-packages'",
+                    "if sp not in sys.path:",
+                    "    sys.path.insert(0, sp)",
+                ]
+            """
+        )
+    sitepackages = f"{prefix}/lib/python{pymaj}.{pymin}/site-packages"
+    if sitepackages not in sys.path:
+        sys.path.insert(0, sitepackages)
+
     print("📦 Installing...")
 
     condacolab_task = _run_subprocess(
@@ -174,35 +203,6 @@ def install_from_url(
         [f"{prefix}/bin/python", "-m", "pip", "-q", "install", "-U", "https://github.com/googlecolab/colabtools/archive/refs/heads/main.zip", "condacolab"],
         "pip_task.log"
         )
-
-    print("📌 Adjusting configuration...")
-    cuda_version = ".".join(os.environ.get("CUDA_VERSION", "*.*.*").split(".")[:2])
-    prefix = Path(prefix)
-    condameta = prefix / "conda-meta"
-    condameta.mkdir(parents=True, exist_ok=True)
-    pymaj, pymin = sys.version_info[:2]
-
-    with open(condameta / "pinned", "a") as f:
-        f.write(f"python {pymaj}.{pymin}.*\n")
-        f.write(f"python_abi {pymaj}.{pymin}.* *cp{pymaj}{pymin}*\n")
-        f.write(f"cudatoolkit {cuda_version}.*\n")
-
-    with open(prefix / ".condarc", "a") as f:
-        f.write("always_yes: true\n")
-
-    with open("/etc/ipython/ipython_config.py", "a") as f:
-        f.write(
-            f"""\nc.InteractiveShellApp.exec_lines = [
-                    "import sys",
-                    "sp = f'{prefix}/lib/python{pymaj}.{pymin}/site-packages'",
-                    "if sp not in sys.path:",
-                    "    sys.path.insert(0, sp)",
-                ]
-            """
-        )
-    sitepackages = f"{prefix}/lib/python{pymaj}.{pymin}/site-packages"
-    if sitepackages not in sys.path:
-        sys.path.insert(0, sitepackages)
 
     env = env or {}
     bin_path = f"{prefix}/bin"

--- a/condacolab.py
+++ b/condacolab.py
@@ -80,8 +80,7 @@ def _run_subprocess(command, logs_filename):
         )
 
     logs_file_path = "/var/condacolab"
-    if not os.path.exists(logs_file_path):
-        os.mkdir(logs_file_path)
+    os.makedirs(logs_file_path, exist_ok=True)
 
     with open(f"{logs_file_path}/{logs_filename}", "w") as f:
         f.write(task.stdout)
@@ -144,29 +143,12 @@ def install_from_url(
     prefix = Path(prefix)
     condameta = prefix / "conda-meta"
     condameta.mkdir(parents=True, exist_ok=True)
-    pymaj, pymin = sys.version_info[:2]
 
     with open(condameta / "pinned", "a") as f:
-        f.write(f"python {pymaj}.{pymin}.*\n")
-        f.write(f"python_abi {pymaj}.{pymin}.* *cp{pymaj}{pymin}*\n")
         f.write(f"cudatoolkit {cuda_version}.*\n")
 
     with open(prefix / ".condarc", "a") as f:
         f.write("always_yes: true\n")
-
-    with open("/etc/ipython/ipython_config.py", "a") as f:
-        f.write(
-            f"""\nc.InteractiveShellApp.exec_lines = [
-                    "import sys",
-                    "sp = f'{prefix}/lib/python{pymaj}.{pymin}/site-packages'",
-                    "if sp not in sys.path:",
-                    "    sys.path.insert(0, sp)",
-                ]
-            """
-        )
-    sitepackages = f"{prefix}/lib/python{pymaj}.{pymin}/site-packages"
-    if sitepackages not in sys.path:
-        sys.path.insert(0, sitepackages)
 
     print("📦 Installing...")
 

--- a/condacolab.py
+++ b/condacolab.py
@@ -250,6 +250,10 @@ def install_mambaforge(
         Run checks to see if installation was run previously.
         Change to False to ignore checks and always attempt
         to run the installation.
+    restart_kernel
+        Variable to manage the kernel restart during the installation
+        of condacolab. Set it `False` to stop the kernel from restarting
+        automatically and get a button instead to do it.
     """
     installer_url = r"https://github.com/jaimergp/miniforge/releases/latest/download/Mambaforge-colab-Linux-x86_64.sh"
     install_from_url(installer_url, prefix=prefix, env=env, run_checks=run_checks, restart_kernel=restart_kernel)
@@ -288,6 +292,10 @@ def install_miniforge(
         Run checks to see if installation was run previously.
         Change to False to ignore checks and always attempt
         to run the installation.
+    restart_kernel
+        Variable to manage the kernel restart during the installation 
+        of condacolab. Set it `False` to stop the kernel from restarting 
+        automatically and get a button instead to do it.
     """
     installer_url = r"https://github.com/jaimergp/miniforge/releases/latest/download/Miniforge-colab-Linux-x86_64.sh"
     install_from_url(installer_url, prefix=prefix, env=env, run_checks=run_checks, restart_kernel=restart_kernel)
@@ -317,6 +325,10 @@ def install_miniconda(
         Run checks to see if installation was run previously.
         Change to False to ignore checks and always attempt
         to run the installation.
+    restart_kernel
+        Variable to manage the kernel restart during the installation 
+        of condacolab. Set it `False` to stop the kernel from restarting 
+        automatically and get a button instead to do it.
     """
     installer_url = r"https://repo.anaconda.com/miniconda/Miniconda3-py37_4.12.0-Linux-x86_64.sh"
     install_from_url(installer_url, prefix=prefix, env=env, run_checks=run_checks, restart_kernel=restart_kernel)
@@ -347,6 +359,10 @@ def install_anaconda(
         Run checks to see if installation was run previously.
         Change to False to ignore checks and always attempt
         to run the installation.
+    restart_kernel
+        Variable to manage the kernel restart during the installation 
+        of condacolab. Set it `False` to stop the kernel from restarting 
+        automatically and get a button instead to do it.
     """
     installer_url = r"https://repo.anaconda.com/archive/Anaconda3-2022.05-Linux-x86_64.sh"
     install_from_url(installer_url, prefix=prefix, env=env, run_checks=run_checks, restart_kernel=restart_kernel)

--- a/condacolab.py
+++ b/condacolab.py
@@ -122,6 +122,10 @@ def install_from_url(
         Run checks to see if installation was run previously.
         Change to False to ignore checks and always attempt
         to run the installation.
+    restart_kernel
+        Variable to manage the kernel restart during the installation 
+        of condacolab. Set it `False` to stop the kernel from restarting 
+        automatically and get a button instead to do it.
     """
     if run_checks:
         try:  # run checks to see if it this was run already

--- a/condacolab.py
+++ b/condacolab.py
@@ -79,9 +79,13 @@ def _run_subprocess(command, logs_filename):
             text=True,
         )
 
-    with open(f"/content/{logs_filename}", "w") as f:
+    logs_file_path = "/var/condacolab"
+    if not os.path.exists(logs_file_path):
+        os.mkdir(logs_file_path)
+
+    with open(f"{logs_file_path}/{logs_filename}", "w") as f:
         f.write(task.stdout)
-    assert (task.returncode == 0), f"💥💔💥 The installation failed! Logs are available at `/content/{logs_filename}`."
+    assert (task.returncode == 0), f"💥💔💥 The installation failed! Logs are available at `{logs_file_path}/{logs_filename}`."
 
 
 def install_from_url(


### PR DESCRIPTION
## Description

1. Moving the logs file created during the installation of condacolab to `/var/condacolab/`.
2. Adding `restart_kernel` parameter to docstring. 
3. Move the tasks (subprocesses) to run after adjusting configurations for files like `.condarc` and pinning dependencies.

[Here](https://colab.research.google.com/drive/1p9WfC_q25W2L8Qn09Xy2HfeoYf3vKglo?usp=sharing) is the example notebook to check how's everything working after these changes.

## Status
- [x] Ready to go