### PR TITLE
API for customizing the conda base environment.

### DIFF
--- a/condacolab.py
+++ b/condacolab.py
@@ -103,6 +103,7 @@ def _update_environment(
     channels: Iterable[str] = (),
     pip_args: Iterable[str] = (),
     extra_conda_args: Iterable[str] = (),
+    conda_exe: str = "conda",
     ):
     """
     Install the dependencies in conda base environment during
@@ -186,7 +187,7 @@ def _update_environment(
             yaml.dump(env_details, f)
 
     _run_subprocess(
-        [f"{prefix}/bin/python", "-m", "conda_env", "update", "-n", "base", "-f", environment_file_path, *extra_conda_args],
+        [conda_exe, "env", "update", "-n", "base", "-f", environment_file_path, *extra_conda_args],
         "environment_file_update.log",
     )
 
@@ -304,6 +305,7 @@ def install_from_url(
         python_version=python_version,
         pip_args=pip_args,
         extra_conda_args=extra_conda_args,
+        conda_exe=f"{prefix}/bin/{conda_exe}",
         )
 
     env = env or {}

--- a/condacolab.py
+++ b/condacolab.py
@@ -297,6 +297,8 @@ def install_from_url(
         "pip_task.log"
         )
 
+    print("📦 Updating enviornment using YAML file...")
+
     _update_environment(
         prefix=prefix,
         environment_file=environment_file,

--- a/condacolab.py
+++ b/condacolab.py
@@ -18,12 +18,19 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from subprocess import check_output, run, PIPE, STDOUT
 from textwrap import dedent
-from typing import Dict, AnyStr
+from typing import Dict, AnyStr, Iterable
 from urllib.request import urlopen
+from urllib.error import HTTPError
 from distutils.spawn import find_executable
 from IPython.display import display
 
 from IPython import get_ipython
+
+try:
+    from ruamel.yaml import YAML
+    from ruamel.yaml.comments import CommentedMap
+except ImportError as e:
+    raise RuntimeError("Could not find ruamel.yaml, plese install using `!pip install ruamel.yaml`!") from e
 
 try:
     import ipywidgets as widgets
@@ -43,6 +50,7 @@ __author__ = (
     "Surbhi Sharma <ssurbhi560@users.noreply.github.com>"
 )
 
+yaml=YAML()
 
 PREFIX = "/opt/conda"
 
@@ -87,12 +95,115 @@ def _run_subprocess(command, logs_filename):
     assert (task.returncode == 0), f"💥💔💥 The installation failed! Logs are available at `{logs_file_path}/{logs_filename}`."
 
 
+def _update_environment(
+    prefix:os.PathLike = PREFIX,
+    environment_file: str = None,
+    python_version: str = None,
+    specs: Iterable[str] = None,
+    channels: Iterable[str] = None,
+    pip_args: Iterable[str] = None,
+    extra_conda_args: Iterable[str] = None,
+    ):
+    """
+    Install the dependencies in conda base environment during
+    the condacolab installion.
+
+    Parameters
+    ----------
+    prefix
+        Target location for the installation.
+    environment_file
+        Path or URL of the environment.yaml file to use for
+        updating the conda base enviornment.
+    python_version
+        Python version to use in the conda base environment, eg. "3.9".
+    specs
+        List of additional specifications (packages) to install.
+    channels
+        Comma separated list of channels to use in the conda
+        base environment.
+    pip_args
+        List of additional packages to be installed using pip.
+    extra_conda_args
+        Any extra conda arguments to be used during the installation.
+    """
+
+    # When environment.yaml file is not provided.
+    if environment_file is None:
+        env_details = {}
+        if channels:
+            env_details["channels"] = channels
+        if specs:
+            env_details["dependencies"] = specs
+        if python_version:
+            env_details["dependencies"] += [f"python={python_version}"]
+        if pip_args:
+            pip_args_dict = {"pip": pip_args}
+            env_details["dependencies"].append(pip_args_dict)
+        environment_file_path = "/environment.yaml"
+
+        with open(environment_file_path, 'w') as f:
+            yaml.indent(mapping=2, sequence=4, offset=2)
+            yaml.dump(env_details, f)
+    else:
+        # If URL is given for environment.yaml file
+        if environment_file.startswith(("http://", "https://")):
+            environment_file_path = "/environment.yaml"
+            try:
+                with urlopen(environment_file) as response, open(environment_file_path, "wb") as out:
+                    shutil.copyfileobj(response, out)
+            except HTTPError as e:
+                raise HTTPError("The URL you entered is not working, please check it again.") from e
+
+        # If path is given for environment.yaml file
+        else:
+            environment_file_path = environment_file
+
+        with open(environment_file_path, 'r') as f:
+            env_details = yaml.load(f.read())
+
+        for key in env_details:
+            if channels and key == "channels":
+                env_details["channels"].extend(channels)
+            if key == "dependencies":
+                if specs:
+                    env_details["dependencies"].extend(specs)
+                if python_version:
+                    env_details["dependencies"].extend([f"python={python_version}"])
+                if pip_args:
+                    for element in env_details["dependencies"]:
+                        # if pip dependencies are already specified.
+                        if type(element) is CommentedMap and "pip" in element:
+                            element["pip"].extend(pip_args)
+                        # if there are no pip dependencies specified in the yaml file.
+                        else:
+                            pip_args_dict = CommentedMap([("pip", [*pip_args])])
+                            env_details["dependencies"].append(pip_args_dict)
+                        break
+        with open(environment_file_path, 'w') as f:
+            f.truncate(0)
+            yaml.dump(env_details, f)
+
+    extra_conda_args = extra_conda_args or ()
+
+    _run_subprocess(
+        [f"{prefix}/bin/python", "-m", "conda_env", "update", "-n", "base", "-f", environment_file_path, *extra_conda_args],
+        "environment_file_update.log",
+    )
+
+
 def install_from_url(
     installer_url: AnyStr,
     prefix: os.PathLike = PREFIX,
     env: Dict[AnyStr, AnyStr] = None,
     run_checks: bool = True,
     restart_kernel: bool = True,
+    environment_file: str = None,
+    python_version: str = None,
+    specs: Iterable[str] = None,
+    channels: Iterable[str] = None,
+    pip_args: Iterable[str] = None,
+    extra_conda_args: Iterable[str] = None,
 ):
     """
     Download and run a constructor-like installer, patching
@@ -186,6 +297,36 @@ def install_from_url(
         "pip_task.log"
         )
 
+    print("📌 Adjusting configuration...")
+    cuda_version = ".".join(os.environ.get("CUDA_VERSION", "*.*.*").split(".")[:2])
+    prefix = Path(prefix)
+    condameta = prefix / "conda-meta"
+    condameta.mkdir(parents=True, exist_ok=True)
+
+
+    with open(condameta / "pinned", "a") as f:
+        f.write(f"cudatoolkit {cuda_version}.*\n")
+
+    with open(prefix / ".condarc", "a") as f:
+        f.write("always_yes: true\n")
+
+    if environment_file and not specs and not channels and not pip_args and not python_version:
+        extra_conda_args = extra_conda_args or ()
+        _run_subprocess(
+            [f"{prefix}/bin/python", "-m", "conda_env", "update", "-n", "base", "-f", environment_file],
+            "environment_file_update.log",
+        )
+    else:
+        _update_environment(
+            prefix=prefix,
+            environment_file=environment_file,
+            specs=specs,
+            channels=channels,
+            python_version=python_version,
+            pip_args=pip_args,
+            extra_conda_args=extra_conda_args,
+            )
+
     env = env or {}
     bin_path = f"{prefix}/bin"
 
@@ -220,18 +361,26 @@ def install_from_url(
     else:
         print("🔁 Please restart kernel by clicking on Runtime > Restart runtime.")
 
+
 def install_mambaforge(
-    prefix: os.PathLike = PREFIX, env: Dict[AnyStr, AnyStr] = None, run_checks: bool = True, restart_kernel: bool = True,
+    prefix: os.PathLike = PREFIX,
+    env: Dict[AnyStr, AnyStr] = None,
+    run_checks: bool = True,
+    restart_kernel: bool = True,
+    specs: Iterable[str] = None,
+    python_version: str = None,
+    channels: Iterable[str] = None,
+    environment_file: str = None,
+    extra_conda_args: Iterable[str] = None,
+    pip_args: Iterable[str] = None,
+
 ):
     """
     Install Mambaforge, built for Python 3.7.
-
     Mambaforge consists of a Miniconda-like distribution optimized
     and preconfigured for conda-forge packages, and includes ``mamba``,
     a faster ``conda`` implementation.
-
     Unlike the official Miniconda, this is built with the latest ``conda``.
-
     Parameters
     ----------
     prefix
@@ -244,7 +393,6 @@ def install_mambaforge(
         to add those yourself in the raw string. They will
         end up added to a line like ``exec env VAR=VALUE python3...``.
         For example, a value with spaces should be passed as::
-
             env={"VAR": '"a value with spaces"'}
     run_checks
         Run checks to see if installation was run previously.
@@ -256,15 +404,35 @@ def install_mambaforge(
         automatically and get a button instead to do it.
     """
     installer_url = r"https://github.com/jaimergp/miniforge/releases/latest/download/Mambaforge-colab-Linux-x86_64.sh"
-    install_from_url(installer_url, prefix=prefix, env=env, run_checks=run_checks, restart_kernel=restart_kernel)
-
+    install_from_url(
+        installer_url,
+        prefix=prefix, 
+        env=env,
+        run_checks=run_checks,
+        restart_kernel=restart_kernel,
+        specs=specs,
+        python_version=python_version,
+        channels=channels,
+        environment_file=environment_file,
+        extra_conda_args=extra_conda_args,
+        pip_args=pip_args,
+        )
 
 # Make mambaforge the default
 install = install_mambaforge
 
 
 def install_miniforge(
-    prefix: os.PathLike = PREFIX, env: Dict[AnyStr, AnyStr] = None, run_checks: bool = True, restart_kernel: bool = True,
+    prefix: os.PathLike = PREFIX,
+    env: Dict[AnyStr, AnyStr] = None,
+    run_checks: bool = True,
+    restart_kernel: bool = True,
+    specs: Iterable[str] = None,
+    python_version: str = None,
+    channels: Iterable[str] = None,
+    environment_file: str = None,
+    extra_conda_args: Iterable[str] = None,
+    pip_args: Iterable[str] = None,
 ):
     """
     Install Mambaforge, built for Python 3.7.
@@ -298,11 +466,32 @@ def install_miniforge(
         automatically and get a button instead to do it.
     """
     installer_url = r"https://github.com/jaimergp/miniforge/releases/latest/download/Miniforge-colab-Linux-x86_64.sh"
-    install_from_url(installer_url, prefix=prefix, env=env, run_checks=run_checks, restart_kernel=restart_kernel)
+    install_from_url(
+        installer_url,
+        prefix=prefix,
+        env=env,
+        run_checks=run_checks,
+        restart_kernel=restart_kernel,
+        specs=specs,
+        python_version=python_version,
+        channels=channels,
+        environment_file=environment_file,
+        extra_conda_args=extra_conda_args,
+        pip_args=pip_args,
+        )
 
 
 def install_miniconda(
-    prefix: os.PathLike = PREFIX, env: Dict[AnyStr, AnyStr] = None, run_checks: bool = True, restart_kernel: bool = True,
+    prefix: os.PathLike = PREFIX,
+    env: Dict[AnyStr, AnyStr] = None,
+    run_checks: bool = True,
+    restart_kernel: bool = True,
+    specs: Iterable[str] = None,
+    python_version: str = None,
+    channels: Iterable[str] = None,
+    environment_file: str = None,
+    extra_conda_args: Iterable[str] = None,
+    pip_args: Iterable[str] = None,
 ):
     """
     Install Miniconda 4.12.0 for Python 3.7.
@@ -331,11 +520,32 @@ def install_miniconda(
         automatically and get a button instead to do it.
     """
     installer_url = r"https://repo.anaconda.com/miniconda/Miniconda3-py37_4.12.0-Linux-x86_64.sh"
-    install_from_url(installer_url, prefix=prefix, env=env, run_checks=run_checks, restart_kernel=restart_kernel)
+    install_from_url(
+        installer_url,
+        prefix=prefix,
+        env=env,
+        run_checks=run_checks,
+        restart_kernel=restart_kernel,
+        specs=specs,
+        python_version=python_version,
+        channels=channels,
+        environment_file=environment_file,
+        extra_conda_args=extra_conda_args,
+        pip_args=pip_args,
+    )
 
 
 def install_anaconda(
-    prefix: os.PathLike = PREFIX, env: Dict[AnyStr, AnyStr] = None, run_checks: bool = True, restart_kernel: bool = True,
+    prefix: os.PathLike = PREFIX,
+    env: Dict[AnyStr, AnyStr] = None,
+    run_checks: bool = True,
+    restart_kernel: bool = True,
+    specs: Iterable[str] = None,
+    python_version: str = None,
+    channels: Iterable[str] = None,
+    environment_file: str = None,
+    extra_conda_args: Iterable[str] = None,
+    pip_args: Iterable[str] = None,
 ):
     """
     Install Anaconda 2022.05, the latest version built
@@ -365,7 +575,19 @@ def install_anaconda(
         automatically and get a button instead to do it.
     """
     installer_url = r"https://repo.anaconda.com/archive/Anaconda3-2022.05-Linux-x86_64.sh"
-    install_from_url(installer_url, prefix=prefix, env=env, run_checks=run_checks, restart_kernel=restart_kernel)
+    install_from_url(        
+        installer_url,
+        prefix=prefix,
+        env=env,
+        run_checks=run_checks,
+        restart_kernel=restart_kernel,
+        specs=specs,
+        python_version=python_version,
+        channels=channels,
+        environment_file=environment_file,
+        extra_conda_args=extra_conda_args,
+        pip_args=pip_args,
+    )
 
 
 def check(prefix: os.PathLike = PREFIX, verbose: bool = True):
@@ -382,10 +604,6 @@ def check(prefix: os.PathLike = PREFIX, verbose: bool = True):
         Print success message if True
     """
     assert find_executable("conda"), "💥💔💥 Conda not found!"
-
-    pymaj, pymin = sys.version_info[:2]
-    sitepackages = f"{prefix}/lib/python{pymaj}.{pymin}/site-packages"
-    assert sitepackages in sys.path, f"💥💔💥 PYTHONPATH was not patched! Value: {sys.path}"
     assert all(
         not path.startswith("/usr/local/") for path in sys.path
     ), f"💥💔💥 PYTHONPATH include system locations: {[path for path in sys.path if path.startswith('/usr/local')]}!"

--- a/condacolab.py
+++ b/condacolab.py
@@ -331,20 +331,21 @@ def install_from_url(
 
     if os.path.exists(sys.executable):
         os.rename(sys.executable, f"{sys.executable}.renamed_by_condacolab.bak")
-        with open(sys.executable, "w") as f:
-            f.write(
-                dedent(
-                    f"""
-                    #!/bin/bash
-                    source {prefix}/etc/profile.d/conda.sh
-                    conda activate
-                    unset PYTHONPATH
-                    mv /usr/bin/lsb_release /usr/bin/lsb_release.renamed_by_condacolab.bak
-                    exec {bin_path}/python $@
-                    """
-                ).lstrip()
-            )
-        run(["chmod", "+x", sys.executable])
+
+    with open(sys.executable, "w") as f:
+        f.write(
+            dedent(
+                f"""
+                #!/bin/bash
+                source {prefix}/etc/profile.d/conda.sh
+                conda activate
+                unset PYTHONPATH
+                mv /usr/bin/lsb_release /usr/bin/lsb_release.renamed_by_condacolab.bak
+                exec {bin_path}/python $@
+                """
+            ).lstrip()
+        )
+    run(["chmod", "+x", sys.executable])
 
     taken = timedelta(seconds=round((datetime.now() - t0).total_seconds(), 0))
     print(f"⏲ Done in {taken}")

--- a/condacolab.py
+++ b/condacolab.py
@@ -30,10 +30,13 @@ try:
     from ruamel.yaml import YAML
     from ruamel.yaml.comments import CommentedMap
 except ImportError as e:
-    raise RuntimeError("Could not find ruamel.yaml, plese install using `!pip install ruamel.yaml`!") from e
+    raise RuntimeError(
+        "Could not find ruamel.yaml, plese install using `!pip install ruamel.yaml`!"
+    ) from e
 
 try:
     import ipywidgets as widgets
+
     HAS_IPYWIDGETS = True
 except ImportError:
     HAS_IPYWIDGETS = False
@@ -50,21 +53,23 @@ __author__ = (
     "Surbhi Sharma <ssurbhi560@users.noreply.github.com>"
 )
 
-yaml=YAML()
+yaml = YAML()
 
 PREFIX = "/opt/conda"
 
 if HAS_IPYWIDGETS:
     restart_kernel_button = widgets.Button(description="Restart kernel now...")
-    restart_button_output = widgets.Output(layout={'border': '1px solid black'})
+    restart_button_output = widgets.Output(layout={"border": "1px solid black"})
 else:
     restart_kernel_button = restart_button_output = None
 
+
 def _on_button_clicked(b):
-  with restart_button_output:
-    get_ipython().kernel.do_shutdown(True)
-    print("Kernel restarted!")
-    restart_kernel_button.close()
+    with restart_button_output:
+        get_ipython().kernel.do_shutdown(True)
+        print("Kernel restarted!")
+        restart_kernel_button.close()
+
 
 def _run_subprocess(command, logs_filename):
     """
@@ -80,23 +85,25 @@ def _run_subprocess(command, logs_filename):
     """
 
     task = run(
-            command,
-            check=False,
-            stdout=PIPE,
-            stderr=STDOUT,
-            text=True,
-        )
+        command,
+        check=False,
+        stdout=PIPE,
+        stderr=STDOUT,
+        text=True,
+    )
 
     logs_file_path = "/var/condacolab"
     os.makedirs(logs_file_path, exist_ok=True)
 
     with open(f"{logs_file_path}/{logs_filename}", "w") as f:
         f.write(task.stdout)
-    assert (task.returncode == 0), f"💥💔💥 The installation failed! Logs are available at `{logs_file_path}/{logs_filename}`."
+    assert task.returncode == 0, (
+        f"💥💔💥 The installation failed! Logs are available at `{logs_file_path}/{logs_filename}`."
+    )
 
 
 def _update_environment(
-    prefix:os.PathLike = PREFIX,
+    prefix: os.PathLike = PREFIX,
     environment_file: str = None,
     python_version: str = None,
     specs: Iterable[str] = (),
@@ -104,7 +111,7 @@ def _update_environment(
     pip_args: Iterable[str] = (),
     extra_conda_args: Iterable[str] = (),
     conda_exe: str = "conda",
-    ):
+):
     """
     Install the dependencies in conda base environment during
     the condacolab installion.
@@ -144,23 +151,28 @@ def _update_environment(
             pip_args_dict = {"pip": pip_args}
             env_details["dependencies"].append(pip_args_dict)
 
-        with open(environment_file_path, 'w') as f:
+        with open(environment_file_path, "w") as f:
             yaml.indent(mapping=2, sequence=4, offset=2)
             yaml.dump(env_details, f)
     else:
         # If URL is given for environment.yaml file
         if environment_file.startswith(("http://", "https://")):
             try:
-                with urlopen(environment_file) as response, open(environment_file_path, "wb") as out:
+                with (
+                    urlopen(environment_file) as response,
+                    open(environment_file_path, "wb") as out,
+                ):
                     shutil.copyfileobj(response, out)
             except HTTPError as e:
-                raise HTTPError("The URL you entered is not working, please check it again.") from e
+                raise HTTPError(
+                    "The URL you entered is not working, please check it again."
+                ) from e
 
         # If path is given for environment.yaml file
         else:
             shutil.copy(environment_file, environment_file_path)
 
-        with open(environment_file_path, 'r') as f:
+        with open(environment_file_path, "r") as f:
             env_details = yaml.load(f.read())
 
         for key in env_details:
@@ -182,12 +194,21 @@ def _update_environment(
                         pip_args_dict = CommentedMap([("pip", [*pip_args])])
                         env_details["dependencies"].append(pip_args_dict)
 
-        with open(environment_file_path, 'w') as f:
+        with open(environment_file_path, "w") as f:
             f.truncate(0)
             yaml.dump(env_details, f)
 
     _run_subprocess(
-        [conda_exe, "env", "update", "-n", "base", "-f", environment_file_path, *extra_conda_args],
+        [
+            conda_exe,
+            "env",
+            "update",
+            "-n",
+            "base",
+            "-f",
+            environment_file_path,
+            *extra_conda_args,
+        ],
         "environment_file_update.log",
     )
 
@@ -233,8 +254,8 @@ def install_from_url(
         Change to False to ignore checks and always attempt
         to run the installation.
     restart_kernel
-        Variable to manage the kernel restart during the installation 
-        of condacolab. Set it `False` to stop the kernel from restarting 
+        Variable to manage the kernel restart during the installation
+        of condacolab. Set it `False` to stop the kernel from restarting
         automatically and get a button instead to do it.
     """
     if run_checks:
@@ -252,7 +273,7 @@ def install_from_url(
     condacolab_task = _run_subprocess(
         ["bash", installer_fn, "-bfp", str(prefix)],
         "condacolab_install.log",
-        )
+    )
 
     print("📌 Adjusting configuration...")
     cuda_version = ".".join(os.environ.get("CUDA_VERSION", "*.*.*").split(".")[:2])
@@ -268,11 +289,11 @@ def install_from_url(
 
     print("📦 Installing...")
 
-# Installing the following packages because Colab server expects these packages to be installed in order to launch a Python kernel:
-#     - matplotlib-base
-#     - psutil
-#     - google-colab
-#     - colabtools
+    # Installing the following packages because Colab server expects these packages to be installed in order to launch a Python kernel:
+    #     - matplotlib-base
+    #     - psutil
+    #     - google-colab
+    #     - colabtools
 
     conda_exe = "mamba" if os.path.isfile(f"{prefix}/bin/mamba") else "conda"
 
@@ -280,7 +301,7 @@ def install_from_url(
 
     output = check_output([f"{prefix}/bin/conda", "list", "--json"])
     payload = json.loads(output)
-    installed_names = [pkg["name"] for pkg in payload] 
+    installed_names = [pkg["name"] for pkg in payload]
     required_packages = ["matplotlib-base", "psutil", "google-colab"]
     for pkg in required_packages.copy():
         if pkg in installed_names:
@@ -293,9 +314,18 @@ def install_from_url(
         )
 
     pip_task = _run_subprocess(
-        [f"{prefix}/bin/python", "-m", "pip", "-q", "install", "-U", "https://github.com/googlecolab/colabtools/archive/refs/heads/main.zip", "condacolab"],
-        "pip_task.log"
-        )
+        [
+            f"{prefix}/bin/python",
+            "-m",
+            "pip",
+            "-q",
+            "install",
+            "-U",
+            "https://github.com/googlecolab/colabtools/archive/refs/heads/main.zip",
+            "condacolab",
+        ],
+        "pip_task.log",
+    )
 
     print("📦 Updating enviornment using YAML file...")
 
@@ -308,7 +338,7 @@ def install_from_url(
         pip_args=pip_args,
         extra_conda_args=extra_conda_args,
         conda_exe=f"{prefix}/bin/{conda_exe}",
-        )
+    )
 
     env = env or {}
     bin_path = f"{prefix}/bin"
@@ -357,7 +387,6 @@ def install_mambaforge(
     environment_file: str = None,
     extra_conda_args: Iterable[str] = (),
     pip_args: Iterable[str] = (),
-
 ):
     """
     Install Mambaforge, built for Python 3.7.
@@ -390,7 +419,7 @@ def install_mambaforge(
     installer_url = r"https://github.com/jaimergp/miniforge/releases/latest/download/Mambaforge-colab-Linux-x86_64.sh"
     install_from_url(
         installer_url,
-        prefix=prefix, 
+        prefix=prefix,
         env=env,
         run_checks=run_checks,
         restart_kernel=restart_kernel,
@@ -400,7 +429,8 @@ def install_mambaforge(
         environment_file=environment_file,
         extra_conda_args=extra_conda_args,
         pip_args=pip_args,
-        )
+    )
+
 
 # Make mambaforge the default
 install = install_mambaforge
@@ -445,8 +475,8 @@ def install_miniforge(
         Change to False to ignore checks and always attempt
         to run the installation.
     restart_kernel
-        Variable to manage the kernel restart during the installation 
-        of condacolab. Set it `False` to stop the kernel from restarting 
+        Variable to manage the kernel restart during the installation
+        of condacolab. Set it `False` to stop the kernel from restarting
         automatically and get a button instead to do it.
     """
     installer_url = r"https://github.com/jaimergp/miniforge/releases/latest/download/Miniforge-colab-Linux-x86_64.sh"
@@ -462,7 +492,7 @@ def install_miniforge(
         environment_file=environment_file,
         extra_conda_args=extra_conda_args,
         pip_args=pip_args,
-        )
+    )
 
 
 def install_miniconda(
@@ -499,11 +529,13 @@ def install_miniconda(
         Change to False to ignore checks and always attempt
         to run the installation.
     restart_kernel
-        Variable to manage the kernel restart during the installation 
-        of condacolab. Set it `False` to stop the kernel from restarting 
+        Variable to manage the kernel restart during the installation
+        of condacolab. Set it `False` to stop the kernel from restarting
         automatically and get a button instead to do it.
     """
-    installer_url = r"https://repo.anaconda.com/miniconda/Miniconda3-py37_4.12.0-Linux-x86_64.sh"
+    installer_url = (
+        r"https://repo.anaconda.com/miniconda/Miniconda3-py37_4.12.0-Linux-x86_64.sh"
+    )
     install_from_url(
         installer_url,
         prefix=prefix,
@@ -554,12 +586,14 @@ def install_anaconda(
         Change to False to ignore checks and always attempt
         to run the installation.
     restart_kernel
-        Variable to manage the kernel restart during the installation 
-        of condacolab. Set it `False` to stop the kernel from restarting 
+        Variable to manage the kernel restart during the installation
+        of condacolab. Set it `False` to stop the kernel from restarting
         automatically and get a button instead to do it.
     """
-    installer_url = r"https://repo.anaconda.com/archive/Anaconda3-2022.05-Linux-x86_64.sh"
-    install_from_url(        
+    installer_url = (
+        r"https://repo.anaconda.com/archive/Anaconda3-2022.05-Linux-x86_64.sh"
+    )
+    install_from_url(
         installer_url,
         prefix=prefix,
         env=env,
@@ -588,15 +622,15 @@ def check(prefix: os.PathLike = PREFIX, verbose: bool = True):
         Print success message if True
     """
     assert find_executable("conda"), "💥💔💥 Conda not found!"
-    assert all(
-        not path.startswith("/usr/local/") for path in sys.path
-    ), f"💥💔💥 PYTHONPATH include system locations: {[path for path in sys.path if path.startswith('/usr/local')]}!"
-    assert (
-        f"{prefix}/bin" in os.environ["PATH"]
-    ), f"💥💔💥 PATH was not patched! Value: {os.environ['PATH']}"
-    assert (
-        prefix == os.environ.get("CONDA_PREFIX")
-    ), f"💥💔💥 CONDA_PREFIX value: {os.environ.get('CONDA_PREFIX', '<not set>')} does not match conda installation location {prefix}!"
+    assert all(not path.startswith("/usr/local/") for path in sys.path), (
+        f"💥💔💥 PYTHONPATH include system locations: {[path for path in sys.path if path.startswith('/usr/local')]}!"
+    )
+    assert f"{prefix}/bin" in os.environ["PATH"], (
+        f"💥💔💥 PATH was not patched! Value: {os.environ['PATH']}"
+    )
+    assert prefix == os.environ.get("CONDA_PREFIX"), (
+        f"💥💔💥 CONDA_PREFIX value: {os.environ.get('CONDA_PREFIX', '<not set>')} does not match conda installation location {prefix}!"
+    )
 
     if verbose:
         print("✨🍰✨ Everything looks OK!")


### PR DESCRIPTION
## Description

In this PR, we provide an API for users to customize the conda base environment during the condacolab's installation. Users will have the following options to specify:

1. `environment_file` - This can be a URL or path to an environment.yaml file.
2. `specs` - This is a list of additional specifications (packages) to install.
3. `python_version` - Python version to use in the conda base environment, _**eg. "3.9"**._
4. `channels` - Comma-separated list of channels to use in the conda base environment.
5. `pip_args` - List of additional packages to be installed using pip
6. `extra_conda_args` - This is a list of any extra conda arguments used during the installation.

You can check this example notebook demonstrating the new feature [here](https://colab.research.google.com/drive/1-FJ7pRpLx0Q1nygD2vHuFKtn7SBT0rC0?usp=sharing).

## Status
- [x] Ready to go